### PR TITLE
Implemented subdomain routing.

### DIFF
--- a/backend/app.js
+++ b/backend/app.js
@@ -1,17 +1,12 @@
-var express = require('express');
-var path = require('path');
-var favicon = require('serve-favicon');
-var logger = require('morgan');
-var cookieParser = require('cookie-parser');
-var bodyParser = require('body-parser');
+const express = require('express');
+const path = require('path');
+const logger = require('morgan');
+const cookieParser = require('cookie-parser');
+const bodyParser = require('body-parser');
 
-var handlers = require('./handlers');
+const handlers = require('./handlers');
 
-var app = express();
-
-// uncomment after placing your favicon in /public
-//app.use(favicon(path.join(__dirname, 'public', 'favicon.ico')));
-
+const app = express();
 
 
 app.use(logger('dev'));

--- a/backend/networkutil.js
+++ b/backend/networkutil.js
@@ -59,7 +59,7 @@ module.exports = {
     },
 
     GetUserPages: async function (connection, userID){
-        let [results, fields] = await connection.query('SELECT * from pages WHERE userID = ?', [userID]);
+        let [results, fields] = await connection.query('SELECT * from pages WHERE userID = ? OR author = ?', [userID, userID]);
         return results;
     }
 

--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -1,3 +1,4 @@
+const isProd = process.env.NODE_ENV === 'production'
 module.exports = {
   webpackDevMiddleware: config => {
     // Solve compiling problem via vagrant
@@ -6,5 +7,6 @@ module.exports = {
       aggregateTimeout: 300 // delay before rebuilding
     };
     return config;
-  }
+  },
+  assetPrefix: isProd ? 'http://gupwd.com' : 'http://localhost:3000'
 };

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,6 +7,7 @@
     "axios": "^0.16.2",
     "bulma": "^0.6.0",
     "express": "^4.16.2",
+    "express-subdomain": "^1.0.5",
     "feather-icons": "^3.3.0",
     "js-cookie": "^2.1.4",
     "next": "^4.0.4",
@@ -19,6 +20,7 @@
     "read-blob": "^1.1.0",
     "styled-components": "^2.2.1",
     "url-parse": "^1.1.9",
+    "wildcard-subdomains": "^1.1.0",
     "yarn": "^1.2.1"
   },
   "scripts": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,7 +7,6 @@
     "axios": "^0.16.2",
     "bulma": "^0.6.0",
     "express": "^4.16.2",
-    "express-subdomain": "^1.0.5",
     "feather-icons": "^3.3.0",
     "js-cookie": "^2.1.4",
     "next": "^4.0.4",
@@ -20,7 +19,6 @@
     "read-blob": "^1.1.0",
     "styled-components": "^2.2.1",
     "url-parse": "^1.1.9",
-    "wildcard-subdomains": "^1.1.0",
     "yarn": "^1.2.1"
   },
   "scripts": {

--- a/frontend/server.js
+++ b/frontend/server.js
@@ -1,5 +1,6 @@
 const express = require('express')
 const next = require('next')
+const subdomain = require('wildcard-subdomains');
 
 const dev = process.env.NODE_ENV !== 'production'
 const app = next({ dev })
@@ -7,14 +8,16 @@ const handle = app.getRequestHandler()
 const port = dev ? 3000 : 80;
 
 app.prepare().then(() => {
-  const server = express()
+  const server = express();
+  
+  server.use(subdomain({namespace: 'u', whitelist: ['www'] }));  
 
   server.get('/u/:userID', (req, res) => {
     const actualPage = '/user'
     const queryParams = { userID: req.params.userID } 
     app.render(req, res, actualPage, queryParams)
   })
-
+  
   server.get('/p/:pageID/:userID', (req, res) => {
     const actualPage = '/page'
     const queryParams = {                           

--- a/frontend/server.js
+++ b/frontend/server.js
@@ -1,6 +1,6 @@
 const express = require('express')
 const next = require('next')
-const subdomain = require('wildcard-subdomains');
+const subdomain = require('./src/lib/Subdomain');
 
 const dev = process.env.NODE_ENV !== 'production'
 const app = next({ dev })
@@ -9,7 +9,7 @@ const port = dev ? 3000 : 80;
 
 app.prepare().then(() => {
   const server = express();
-  
+
   server.use(subdomain({namespace: 'u', whitelist: ['www'] }));  
 
   server.get('/u/:userID', (req, res) => {

--- a/frontend/src/api/constants.js
+++ b/frontend/src/api/constants.js
@@ -1,7 +1,11 @@
 let BASE_URL = "http://localhost:8080";
-if (process.env.NODE_ENV === "production") {
+let ASSET_URL = "http://localhost:3000"
+const isProd = process.env.NODE_ENV === 'production'
+if (isProd) {
   BASE_URL = "http://gupwd.com:8080";
+  ASSET_URL = "http://gupwd.com"
   console.log("Running using production host!"); // eslint-disable-line no-console
+
 }
 
 const USER_ROUTE = "/users";
@@ -13,6 +17,7 @@ const UPLOAD_ROUTE = "/pages/new"
 const USER_PAGE_ROUTE = "/users"
 export {
   BASE_URL,
+  ASSET_URL,
   USER_ROUTE,
   PAGE_ROUTE,
   REGISTER_ROUTE,

--- a/frontend/src/components/TopBar.js
+++ b/frontend/src/components/TopBar.js
@@ -3,6 +3,7 @@ import styled from "styled-components";
 import Link from "next/link";
 import Title from "./Title";
 import RedirectToLogin from "./RedirectToLogin";
+const Constants = require('../api/constants');
 
 const Icon = styled.div`
   padding: 5px;
@@ -54,6 +55,7 @@ function DirectoryTitle(props){
           -moz-transition: color 0.25s, font-size 0.25s;
           -o-transition: color 0.25s, font-size 0.25s;
           transition: color 0.25s, font-size 0.25s;
+          color: #282828;
         }
         
         .breadcrumb:hover{
@@ -63,7 +65,7 @@ function DirectoryTitle(props){
 
         <code>
           {"$ cat ~/"}
-          <Link prefetch href={'/'}><span className="breadcrumb">{"gonzaga"}</span></Link>
+          <a href={Constants.ASSET_URL}><span className="breadcrumb">{"gonzaga"}</span></a>
           {"/"}
           <Link prefetch
             as={ "/u/" + userID}
@@ -88,6 +90,7 @@ function DirectoryTitle(props){
           -moz-transition: color 0.25s, font-size 0.25s;
           -o-transition: color 0.25s, font-size 0.25s;
           transition: color 0.25s, font-size 0.25s;
+          color: #282828;
         }
         
         .breadcrumb:hover{
@@ -96,7 +99,7 @@ function DirectoryTitle(props){
         }`}</style>
         <code>
           {"$ cd ~/"}
-          <Link prefetch href={'/'}><span className="breadcrumb">{"gonzaga"}</span></Link>
+          <a href={Constants.ASSET_URL}><span className="breadcrumb">{"gonzaga"}</span></a>
           {"/" + author + " && pwd "}</code>
       </Title>
     );

--- a/frontend/src/lib/Subdomain.js
+++ b/frontend/src/lib/Subdomain.js
@@ -1,0 +1,39 @@
+module.exports = function (options) {
+    options = options || {}
+    var path = '/' + (options.namespace || '_sub') + '/'
+  
+    // Support previous `www` boolean option
+    var whitelist = options.www === false ? [] : ['www']
+  
+    if (typeof options.whitelist === 'string') {
+      whitelist = [options.whitelist]
+    } else if (Array.isArray(options.whitelist)) {
+      whitelist = options.whitelist
+    }
+  
+    return function (req, res, next) {
+      if(req.url != "/"){
+        next();
+        return;   
+      }
+      var subdomains = req.subdomains
+      var host = req.hostname
+  
+      var inWhitelist = whitelist.some(function(subdomain) {
+        var i = subdomains.indexOf(subdomain)
+        return i > -1
+      })
+  
+      if (inWhitelist) return next()
+  
+      // continue if no subdomains
+      if (!subdomains.length) return next()
+  
+      // rebuild url
+      req.url = path + subdomains.join('/') + req.url
+  
+      // Q.E.D.
+      next()
+    }
+  }
+  

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -2081,6 +2081,10 @@ expand-range@^1.8.1:
   dependencies:
     fill-range "^2.1.0"
 
+express-subdomain@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/express-subdomain/-/express-subdomain-1.0.5.tgz#990ef97940b7f4c2823d9593648b79be858a638b"
+
 express@^4.16.2:
   version "4.16.2"
   resolved "https://registry.yarnpkg.com/express/-/express-4.16.2.tgz#e35c6dfe2d64b7dca0a5cd4f21781be3299e076c"
@@ -5402,6 +5406,10 @@ wide-align@^1.1.0:
   resolved "https://registry.yarnpkg.com/wide-align/-/wide-align-1.1.2.tgz#571e0f1b0604636ebc0dfc21b0339bbe31341710"
   dependencies:
     string-width "^1.0.2"
+
+wildcard-subdomains@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/wildcard-subdomains/-/wildcard-subdomains-1.1.0.tgz#f983727551b8cec6c7bd8795f8ccc14296aba22b"
 
 window-size@0.1.0:
   version "0.1.0"


### PR DESCRIPTION
This pull request implements subdomain user routing.
For example...

http://maxchehab.gupwd.com/ is the same as http://gupwd.com/u/{userID}.

**If you want to try this out with a** `localhost` **address you must apend some random subdomain after** `username` **. Ex:** http://maxchehab.test.localhost.